### PR TITLE
make it possible to run with single default model

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -53,7 +53,7 @@ function resolveModelConfig(value, basedir) {
 function normalize(config, options) {
     options = options || {};
 
-    const { model, basedir, cachedir } = options;
+    let { model, basedir, cachedir } = options;
     const cwd = process.env.PWD || process.cwd();
     let models;
     let result;
@@ -86,7 +86,7 @@ function normalize(config, options) {
     result.models = Object.keys(models).reduce((res, slug) => {
         if (!model || model === slug) {
             const modelConfig = normalizeModelConfig(
-                Object.assign({ slug }, resolveModelConfig(config.models[slug], basedir))
+                Object.assign({ slug }, resolveModelConfig(models[slug], basedir))
             );
 
             switch (modelConfig.cache) {


### PR DESCRIPTION
without this changes you can not use this config

.discoveryrc.js
```
module.exports = {
    "name": "Angular Docs",
    data: require('./doc/crawler.js').default,
    cache: true,
    prepare: __dirname + '/doc/prepare.js',
    view: {
        basedir: __dirname,
        assets: [
            './doc/ui/page/dashboard.js',
            './doc/ui/page/file.js',
            './doc/ui/sidebar.js'
        ]
    }
}
```