### PR TITLE
disable user-select for content-badges

### DIFF
--- a/client/widget/index.css
+++ b/client/widget/index.css
@@ -81,6 +81,7 @@ a:hover {
     right: 40px;
     border-radius: 0 0 5px 5px;
     overflow: hidden;
+    user-select: none;
 }
 .discovery-content-badges > .badge {
     float: left;


### PR DESCRIPTION
Привет и спасибо! :)

Проблема, с которой я периодически сталкиваюсь - я открываю json-discovery и жмакаю cmd+a и cmd+c и ожидаю, что я скопировал json целиком. А оказывается, не только его, а еще и беджики справа сверху.

Мне кажется, можно (наверное даже нужно) сделать их невыделяемыми. Что думаешь? Переключаться в Raw только для этого - ну фиг знает.

Или лучше это вообще сделать в самом расширении? Но тогда нужно будет завязываться на название класса, тоже наверное не очень хорошо <_<