### PR TITLE
Allow configuration of maxStringLength and maxLinearStringLength for struct view

### DIFF
--- a/src/views/struct/index.js
+++ b/src/views/struct/index.js
@@ -19,10 +19,10 @@ const hasOwnProperty = Object.prototype.hasOwnProperty;
 const toString = Object.prototype.toString;
 const defaultExpandedItemsLimit = 50;
 const defaultCollapsedItemsLimit = 4;
-const maxStringLength = 150;
-const maxLinearStringLength = 50;
+const defaultMaxStringLength = 165;
+const defaultLinearStringLength = 65;
 
-function isValueExpandable(value) {
+function isValueExpandable(value, maxStringLength) {
     // array
     if (Array.isArray(value)) {
         return value.length > 0;
@@ -148,7 +148,7 @@ export default function(host) {
     }
 
     function renderValue(container, value, autoExpandLimit, options, context) {
-        const expandable = isValueExpandable(value);
+        const expandable = isValueExpandable(value, options.maxStringLength);
         const valueEl = valueProtoEl.cloneNode(true);
 
         elementData.set(valueEl, value);
@@ -437,8 +437,16 @@ export default function(host) {
     host.addHostElEventListener('click', clickHandler, false);
 
     host.view.define('struct', function(el, config, data) {
-        const { expanded, limit, limitCollapsed, annotations } = config;
-        const expandable = isValueExpandable(data);
+        const {
+            expanded,
+            limit,
+            limitCollapsed,
+            annotations,
+            maxStringLength = defaultMaxStringLength,
+            maxLinearStringLength = defaultLinearStringLength
+        } = config;
+
+        const expandable = isValueExpandable(data, maxStringLength);
         const options = {
             limitCollapsed: host.view.listLimit(limitCollapsed, defaultCollapsedItemsLimit),
             limit: host.view.listLimit(limit, defaultExpandedItemsLimit),

--- a/src/views/struct/struct.usage.js
+++ b/src/views/struct/struct.usage.js
@@ -40,6 +40,25 @@ export default {
                     level1_7: 7
                 }
             }
+        },
+        {
+            title: 'Set up maxStringLength and maxLineraStringLength for string values',
+            beforeDemo: 'maxStringLength defines max length for string values. maxLinearStringLength defines max length for string values inside objects values ',
+            demo: {
+                view: 'struct',
+                expanded: 2,
+                maxStringLength: 20,
+                maxLinearStringLength: 10,
+                data: {
+                    string: 'Quite a long string value',
+                    level1: {
+                        string: 'Quite a long string value',
+                        level2: {
+                            linerString: 'Quite a long string value'
+                        }
+                    }
+                }
+            }
         }
     ]
 };

--- a/src/views/struct/value-to-html.js
+++ b/src/views/struct/value-to-html.js
@@ -36,7 +36,7 @@ export default function value2html(value, linear, options) {
         case 'string': {
             const maxLength = linear ? options.maxLinearStringLength : options.maxStringLength;
 
-            if (value.length > maxLength + 15) {
+            if (value.length > maxLength) {
                 return token(
                     'string',
                     escapeHtml(JSON.stringify(value.slice(0, maxLength)).slice(0, -1)) +


### PR DESCRIPTION
### What changed

1. Move maxStringLength and maxLinearStringLength to config of struct view
2. Simplify condition inside string length comparison to prevent misunderstanding of new properties

### Motivation

I believe this feature might be useful for some projects. For example, it will be convenient for me. I run discovery inside browser devtools and want to tweak these params a little bit on window resize.

If you find my explanation not perfect in src/views/struct/struct.usage.js let me know I fix it.